### PR TITLE
chore: replace `fast-memoize` cache with custom FIFO implementation

### DIFF
--- a/src/base58.test.ts
+++ b/src/base58.test.ts
@@ -19,6 +19,8 @@ const createPayload = () => {
 describe("Base58", () => {
     it("encodeCheck", () => {
         expect(Base58.encodeCheck(createPayload())).toBe("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib");
+        // Check cached
+        expect(Base58.encodeCheck(createPayload())).toBe("D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib");
     });
 
     it("decodeCheck", () => {

--- a/src/base58.ts
+++ b/src/base58.ts
@@ -36,7 +36,7 @@ export const Base58 = {
         cache: {
             // @ts-ignore
             create: () => {
-                return new Cache<string, string>(10000);
+                return new Cache<string, Buffer>(10000);
             },
         },
     }),

--- a/src/base58.ts
+++ b/src/base58.ts
@@ -1,6 +1,7 @@
 import { base58 } from "bstring";
 import moize from "fast-memoize";
 
+import { Cache } from "./cache";
 import { InvalidBase58ChecksumError } from "./errors";
 import { HashAlgorithms } from "./hash-algorithms";
 
@@ -23,6 +24,20 @@ const decodeCheck = (address: string): Buffer => {
 };
 
 export const Base58 = {
-    encodeCheck: moize(encodeCheck),
-    decodeCheck: moize(decodeCheck),
+    encodeCheck: moize(encodeCheck, {
+        cache: {
+            // @ts-ignore
+            create: () => {
+                return new Cache<string, string>(10000);
+            },
+        },
+    }),
+    decodeCheck: moize(decodeCheck, {
+        cache: {
+            // @ts-ignore
+            create: () => {
+                return new Cache<string, string>(10000);
+            },
+        },
+    }),
 };

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -1,0 +1,48 @@
+import "jest-extended";
+
+import { Cache } from "./cache";
+let cache: Cache<string, string>;
+
+describe("Cache", () => {
+    beforeEach(() => {
+        cache = new Cache<string, string>(10);
+    });
+
+    describe("has", () => {
+        it("should return false if key is not set", () => {
+            expect(cache.has("unset key")).toBeFalse();
+        });
+
+        it("should return true if key is set", () => {
+            cache.set("key", "value");
+
+            expect(cache.has("key")).toBeTrue();
+        });
+    });
+
+    describe("get", () => {
+        it("should return undefined if key is not set", () => {
+            expect(cache.get("unset key")).toBeUndefined();
+        });
+
+        it("should return value if key is set", () => {
+            cache.set("key", "value");
+
+            expect(cache.get("key")).toEqual("value");
+        });
+    });
+
+    describe("set", () => {
+        it("should remove elements by insertion order, when length is exceeded", () => {
+            for (let i = 0; i < 10; i++) {
+                cache.set(i.toString(), i.toString());
+            }
+
+            expect(cache.has("0")).toBeTrue();
+
+            cache.set("10", "10");
+
+            expect(cache.has("0")).toBeFalse();
+        });
+    });
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,25 @@
+export class Cache<K, V> {
+    private readonly cache = new Map<K, V>();
+
+    public constructor(private readonly maxSize: number) {}
+
+    public has(key: K): boolean {
+        return this.cache.has(key);
+    }
+
+    public get(key: K): V | undefined {
+        return this.cache.get(key);
+    }
+
+    public set(key: K, value: V): void {
+        this.cache.set(key, value);
+
+        if (this.cache.size > this.maxSize) {
+            this.cache.delete(this.firstKey());
+        }
+    }
+
+    private firstKey(): K {
+        return this.cache.keys().next().value;
+    }
+}


### PR DESCRIPTION
## Summary

Implement custom cache solution that uses FIFO and solves performance bottleneck caused by default cache, when using very high number of entries (more than 4 million) and prevents cache overflow. 

Current implementation have better benchmark position compared to lru-memoize with limit. 

## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
